### PR TITLE
Update log path for osx

### DIFF
--- a/glass-daemon/logger.go
+++ b/glass-daemon/logger.go
@@ -22,7 +22,7 @@ func NewLogger(w io.Writer) (*Logger, error) {
 		return nil, errwrap.Wrapf("Failed to find Timeglass system path: {{err}}", err)
 	}
 
-	l.path = filepath.Join(path, "daemon.log")
+	l.path = filepath.Join(path, "timeglass-daemon.log")
 	l.file, err = os.OpenFile(l.path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
 		return nil, err

--- a/glass-daemon/paths.go
+++ b/glass-daemon/paths.go
@@ -25,7 +25,7 @@ func SystemTimeglassPath() (string, error) {
 		return "", fmt.Errorf("Expected environmnet variable 'PROGRAMDATA' or 'ALLUSERPROFILE'")
 	} else if runtime.GOOS == "darwin" {
 		//osx we can actually create user specific services, and as such, store data for the user specifically
-		return filepath.Join("/", "Library", "Timeglass"), nil
+		return filepath.Join("~", "Library", "Logs"), nil
 	} else if runtime.GOOS == "linux" {
 		return filepath.Join("/var/lib", "timeglass"), nil
 	}


### PR DESCRIPTION
Changes to `~/Library/Logs/timeglass-daemon.log`

Running into a permissions error with the `/Library/Timeglass` path

I'm thinking its also best to use the log directory for the current user, this is the same directory exposed by the Console app and used by many other applications for logging.

Let me know your thoughts.
