### PR TITLE
Fix type error: “gass” → “glass” in docs/query.md

### DIFF
--- a/docs/query.md
+++ b/docs/query.md
@@ -2,7 +2,7 @@
 _Timeglass_ attaches the time you spent as metadata to Git commits. This means you have the full power of Git at your disposal when it comes to querying. This also means that retrieving data will always consists of two steps: 
 
 1. First, select the work you're interested in by fetching a list of commit hashes (seperated by newlines) from Git using either `git rev-list` or `git log --pretty=%H`.
-2. Second, pipe this list into `gass sum` to add all time entries together. It will output thet total time in a human readable format (e.g 1h59m10s)
+2. Second, pipe this list into `glass sum` to add all time entries together. It will output thet total time in a human readable format (e.g 1h59m10s)
 
 Because querying Git can be a science in it own right we included some common patterns below. Have question about your data that isn't answers by any of the examples below? [let us know](https://github.com/timeglass/glass/issues/9)
 


### PR DESCRIPTION
I didn’t found more occurrences in the docs, so this little pull request changes only a single file/line/word.
