### PR TITLE
Tweak markdown for proper formatting

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,4 +1,5 @@
 # Configuration
+
 Timeglass can be configured by creating a `timeglass.json` file in the root of the repository you are tracking. The following example shows all options with their default configuration:
 
 ```json
@@ -29,7 +30,7 @@ __key__: `commit_message`
 
 This options allows you to specify how Timeglass should write time measurments to commit messages. To disable this feature completely, provide an empty string, e.g: `"commit_message": ""`
 
-The template is parsed using the standard Go [text/templating](http://golang.org/pkg/text/template/), but you probably only need to know that `{{.}}` is replaced by a human readable representation of the measured time, e.g: `1h5m2s` 
+The template is parsed using the standard Go [text/templating](http://golang.org/pkg/text/template/), but you probably only need to know that `{{.}}` is replaced by a human readable representation of the measured time, e.g: `1h5m2s`
 
 The `.` represents a [time.Duration](http://golang.org/pkg/time/#Duration) struct. This means that you can also call its individual methods from inside the template, for example the following configuration
 

--- a/docs/manual_installation.md
+++ b/docs/manual_installation.md
@@ -1,4 +1,5 @@
 # Manual Installation
+
 If you're on linx and/or like to have more control over how you install Timeglass we provide two ways for manual installation. If you have a 64bit architecture it is possible to just [download the prebuild binaries](https://github.com/timeglass/glass/releases/latest) and go to step 2, else you should build from source.
 
 ## Step 1: Building from Source (optional)
@@ -14,7 +15,7 @@ The source code will now be in your workspace and binaries are found in `$GOPATH
 
 ## Step 2: Placing the Binaries in your PATH
 
-If you downloaded the prebuild binaries you'll first need to unzip them and the copy the contents to a directory thats in your PATH (e.g. /usr/local/bin). If you build from source the binaries are probably already in your path, if not you must copy or link them there yourself. 
+If you downloaded the prebuild binaries you'll first need to unzip them and the copy the contents to a directory thats in your PATH (e.g. /usr/local/bin). If you build from source the binaries are probably already in your path, if not you must copy or link them there yourself.
 
 Check that this was done successfull by opening a new terminal window and running: `glass`. You should see all the *Timeglass* commands that are now available to you.
 
@@ -25,4 +26,4 @@ An important part of *Timeglass* is the monitoring of file system activity. For 
 
 _NOTE1: **On OSX and linux** this service is currently installed for all accounts and requires you to use sudo: `sudo glass install`_
 
-_NOTE2: **On Windows** this service requires administration privileges so either 'run as Administrator' or log in as the Administrator and run the install command_ 
+_NOTE2: **On Windows** this service requires administration privileges so either 'run as Administrator' or log in as the Administrator and run the install command_

--- a/docs/query.md
+++ b/docs/query.md
@@ -1,5 +1,6 @@
-#Querying your Measurements
-_Timeglass_ attaches the time you spent as metadata to Git commits. This means you have the full power of Git at your disposal when it comes to querying. This also means that retrieving data will always consists of two steps: 
+# Querying your Measurements
+
+_Timeglass_ attaches the time you spent as metadata to Git commits. This means you have the full power of Git at your disposal when it comes to querying. This also means that retrieving data will always consists of two steps:
 
 1. First, select the work you're interested in by fetching a list of commit hashes (seperated by newlines) from Git using either `git rev-list` or `git log --pretty=%H`.
 2. Second, pipe this list into `glass sum` to add all time entries together. It will output thet total time in a human readable format (e.g 1h59m10s)
@@ -33,6 +34,3 @@ Because querying Git can be a science in it own right we included some common pa
 	git rev-list d2192a058^..d2192a058 | glass sum
 
 NOTE: To show all merges that occured: `git log --merges --format=oneline`
-
-
-

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -1,5 +1,6 @@
-#Sharing data with others
-Once you've recorded some time you might want to share your measurements with others. Timeglass uses git-notes and thus stores measurements as metadata in a seperate branch. By default, a "pre-push" hook is installed that automatically pushes your time measurements to the remote whenever you issues a `git push` for regular commits. 
+# Sharing data with others
+
+Once you've recorded some time you might want to share your measurements with others. Timeglass uses git-notes and thus stores measurements as metadata in a seperate branch. By default, a "pre-push" hook is installed that automatically pushes your time measurements to the remote whenever you issues a `git push` for regular commits.
 
 If you disabled this behaviour in the [configuration](/docs/config.md) or if you want to push time data manually you can use:
 
@@ -15,4 +16,3 @@ glass pull [remote]
 ```
 
 After you've pulled time data from the remote you can happely [query](/docs/query.md) it however you like.
-

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -1,5 +1,6 @@
 # Uninstalling
-First off, if you're uninstalling because of some unexpectedly behaviour feel free to create [an issue](https://github.com/timeglass/glass/issues) that explains your problems. I love being in converstation with the user and create the best experience possible. 
+
+First off, if you're uninstalling because of some unexpectedly behaviour feel free to create [an issue](https://github.com/timeglass/glass/issues) that explains your problems. I love being in converstation with the user and create the best experience possible.
 
 That being said, you can do the following in order to remove Timeglass from a single repository:
 
@@ -7,7 +8,7 @@ That being said, you can do the following in order to remove Timeglass from a si
 2. Remove the git hooks timeglass creates from the `.git/hooks` directory of your repo. The following files are created during installation:
 
      - .git/hooks/prepare-commit-msg
-     - .git/hooks/post-commit 
+     - .git/hooks/post-commit
      - .git/hooks/pre-push
 
 If you would like to continue and remove Timeglass from your system entirely, you can continue with the following:


### PR DESCRIPTION
Tweaked the markdown documentation so it formats properly on GitHub.

My editor also slipped in some whitespace changes.